### PR TITLE
Attempt to fix make-local-hook error

### DIFF
--- a/gnuplot.el
+++ b/gnuplot.el
@@ -1864,8 +1864,10 @@ buffer.  Further customization is possible via
 	(process-kill-without-query gnuplot-process nil)
 	(save-excursion
 	  (set-buffer gnuplot-buffer)
-	  (make-local-hook 'kill-buffer-hook)
-	  (add-hook 'kill-buffer-hook 'gnuplot-close-down nil t)
+      ;; 'local does not automatically make hook buffer-local in XEmacs.
+      (if (featurep 'xemacs)
+          (make-local-hook 'kill-buffer-hook))
+      (add-hook 'kill-buffer-hook 'gnuplot-close-down nil t)
 	  (gnuplot-comint-start-function)
           (make-local-variable 'comint-output-filter-functions)
           (setq comint-output-filter-functions


### PR DESCRIPTION
When attempting to use gnuplot-mode with GNU Emacs 24, I get the
following error:

Debugger entered--Lisp error: (void-function make-local-hook)
  make-local-hook(kill-buffer-hook)
  gnuplot-make-gnuplot-buffer()

The problem is described in detail in the debian bug-tracker:

http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=600185

This commit applies the patch suggested by Agustin Martin on that bug
report.
