### PR TITLE
Alter header to conform to package.el specifications

### DIFF
--- a/gnuplot.el
+++ b/gnuplot.el
@@ -1,4 +1,4 @@
-;;;; gnuplot.el -- drive gnuplot from within emacs
+;;; gnuplot.el --- drive gnuplot from within emacs
 
 ;; Copyright (C) 1998, 2011 Phil Type and Bruce Ravel, 1999-2002 Bruce Ravel
 


### PR DESCRIPTION
The header isn't currently being parsed by package.el, so the description doesn't show up in the package list.
