### PR TITLE
Fix gnuplot-mode on Windows

### DIFF
--- a/README.org
+++ b/README.org
@@ -124,7 +124,14 @@
       Gnuplot-mode is already on http://melpa.milkbox.net, but it would
       be good to get it into the other repositories too.
 
-   2. Using gnuplot-mode on windows is problematic.  John Handy says:
+   2. Using gnuplot-mode on windows might be problematic.
+
+      The latest version has been reported to work on Windows 10 and
+      W32 Emacs if you use =cmdproxy.exe= as your =shell-file-name=
+      (the default) and point =gnuplot-program= to =gnuplot.exe= (not
+      =wgnuplot.exe=).
+
+      Nevertheless, John Handy says:
 
       You probably get nagged quite a bit about this. Some have been running into
       issues with gnuplot-mode and Windows and I'm wondering if you have any

--- a/gnuplot.el
+++ b/gnuplot.el
@@ -570,7 +570,8 @@ The values are
 		(const :tag "Separate window" window)
 		(const :tag "This window"     nil)))
 
-(defcustom gnuplot-echo-command-line-flag (not gnuplot-ntemacs-p)
+(defcustom gnuplot-echo-command-line-flag (and (not gnuplot-ntemacs-p)
+                                               (not (eq window-system 'w32)))
   "*This sets the fall-back value of `comint-process-echos'.
 If `gnuplot-mode' cannot figure out what version number of gnuplot
 this is, then the value of this variable will be used for
@@ -2278,7 +2279,14 @@ buffer."
   (unless (and gnuplot-process (eq (process-status gnuplot-process) 'run)
                gnuplot-buffer (buffer-live-p gnuplot-buffer))
     (message "Starting gnuplot plotting program...")
-    (setq gnuplot-buffer (make-comint gnuplot-process-name gnuplot-program)
+    (setq gnuplot-buffer
+          (if (and (eq window-system 'w32)
+                   (string= "cmdproxy.exe"
+                            (file-name-nondirectory shell-file-name)))
+              (make-comint gnuplot-process-name shell-file-name
+                           nil
+                           "/C" (expand-file-name gnuplot-program))
+            (make-comint gnuplot-process-name gnuplot-program))
           gnuplot-process (get-buffer-process gnuplot-buffer))
     (gnuplot-set-process-query-on-exit-flag gnuplot-process nil)
     (with-current-buffer gnuplot-buffer


### PR DESCRIPTION
- README.org: Section about Windows problems rephrased.
- gnuplot.el (gnuplot-echo-command-line-flag): Also check for
  `window-system'
  (gnuplot-make-gnuplot-buffer): Make comint buffer differently when
  on windows.
