### PR TITLE
Tokenize names with non-latin characters

### DIFF
--- a/gnuplot-context.el
+++ b/gnuplot-context.el
@@ -296,7 +296,7 @@ name; otherwise continues tokenizing up to the token at point.  FIXME."
                (token
                 (cond
                  ((gnuplot-tokenize-by-regexps
-                   ("[A-Za-z_][A-Za-z0-9_]*" name)
+                   ("[[:alpha:]_][[:alpha:]0-9_]*" name)
                    ("[0-9]+\\(\\.[0-9]*\\)?\\([eE][+-]?[0-9]+\\)?\\|\\.[0-9]+\\([eE][+-]?[0-9]+\\)?" number)
                    (gnuplot-operator-regexp operator)
                    (";" separator)))


### PR DESCRIPTION
Hi :-) When a gnuplot variable or function name begins with a non-latin letter ElDoc complains: `eldoc error: (error Gnuplot-tokenize: bad token beginning <some bad letter>)`. For instance,  it raises that error when the point is after an `ε` in
```gnuplot
ε(x) = 1/x
plot ε(x)
```
The script is valid and `gnuplot` renders it without any errors.

The [manual](http://gnuplot.info/docs_5.4/Gnuplot_5_4.pdf#page=45) says

> Valid names are the same as in most programming languages: they must begin with a letter, but subsequent
characters may be letters, digits, or "`_`".

So I've replaced `A-Za-z` with `[:alpha:]` in the regexps of the function `gnuplot-tokenize`, and now ElDoc doesn't complain anymore. What do you think?